### PR TITLE
LPS-19798

### DIFF
--- a/portal-web/docroot/html/portlet/bookmarks/view_entry.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/view_entry.jsp
@@ -38,6 +38,7 @@ request.setAttribute("view_entry.jsp-entry", entry);
 	<liferay-ui:header
 		localizeTitle="<%= false %>"
 		title="<%= entry.getName() %>"
+		escapeXml="<%= false %>"
 	/>
 </c:if>
 


### PR DESCRIPTION
entry already is escaped mode, so does not need escaped again in tag header.
