### PR TITLE
LPS-32651

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -271,6 +271,10 @@ public class WebServerServlet extends HttpServlet {
 			PortalUtil.sendError(
 				HttpServletResponse.SC_NOT_FOUND, nsfee, request, response);
 		}
+		catch (NoSuchFolderException nsfe) {
+			PortalUtil.sendError(
+				HttpServletResponse.SC_NOT_FOUND, nsfe, request, response);
+		}
 		catch (PrincipalException pe) {
 			processPrincipalException(pe, user, request, response);
 		}
@@ -690,9 +694,7 @@ public class WebServerServlet extends HttpServlet {
 			PropsValues.WEB_SERVER_SERVLET_DIRECTORY_INDEXING_ENABLED);
 
 		if (!directoryIndexingEnabled) {
-			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-
-			return;
+			throw new NoSuchFolderException();
 		}
 
 		long folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;


### PR DESCRIPTION
Hi Samuel,

I propose following solution to this issue.

Adding  

response.setStatus(HttpServletResponse.SC_FORBIDDEN);

was wrong, but changing that to 

response.setStatus(HttpServletResponse.SC_NOT_FOUND);

would not be good either, since then the result would have been empty as we will provide also nice error page for these. 

The correct way was to use PortalUtil.sendError(..) to do the job.
