### PR TITLE
LPS-43171

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -412,6 +412,16 @@ public class HtmlImpl implements Html {
 	}
 
 	@Override
+	public String toWordCharacters(String text) {
+
+		if (Validator.isNull(text)) {
+			return text;
+		}
+
+		return text.replaceAll("[^\\w]", StringPool.UNDERLINE);
+	}
+
+	@Override
 	public String unescape(String text) {
 		if (text == null) {
 			return null;

--- a/portal-service/src/com/liferay/portal/kernel/util/Html.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Html.java
@@ -58,6 +58,8 @@ public interface Html {
 
 	public String toInputSafe(String text);
 
+	public String toWordCharacters(String text);
+
 	public String unescape(String text);
 
 	public String unescapeCDATA(String text);

--- a/portal-service/src/com/liferay/portal/kernel/util/HtmlUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/HtmlUtil.java
@@ -102,6 +102,10 @@ public class HtmlUtil {
 		return getHtml().toInputSafe(html);
 	}
 
+	public static String toWordCharacters(String html) {
+		return getHtml().toWordCharacters(html);
+	}
+
 	public static String unescape(String html) {
 		return getHtml().unescape(html);
 	}

--- a/portal-web/docroot/html/taglib/ui/custom_attribute/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/custom_attribute/page.jsp
@@ -62,7 +62,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 	<c:if test="<%= !propertyHidden && ExpandoColumnPermissionUtil.contains(permissionChecker, company.getCompanyId(), className, ExpandoTableConstants.DEFAULT_TABLE_NAME, name, ActionKeys.VIEW) %>">
 
 		<%
-		String escapedName = HtmlUtil.escape(name);
+		String escapedName = HtmlUtil.escapeAttribute(name);
 		%>
 
 		<c:choose>
@@ -151,6 +151,9 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 								if ((minute == -1) && (valueDate != null)) {
 									minute = valueDate.get(Calendar.MINUTE);
 								}
+
+								String inputDateName = fieldParam + "Date";
+								String inputTimeName = fieldParam + "Time";
 								%>
 
 								<liferay-ui:input-date
@@ -160,6 +163,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 									firstDayOfWeek="<%= valueDate.getFirstDayOfWeek() - 1 %>"
 									monthParam='<%= fieldParam + "Month" %>'
 									monthValue="<%= month %>"
+									name="<%= inputDateName %>"
 									yearParam='<%= fieldParam + "Year" %>'
 									yearValue="<%= year %>"
 								/>
@@ -172,6 +176,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 									hourValue="<%= hour %>"
 									minuteParam='<%= fieldParam + "Minute" %>'
 									minuteValue="<%= minute %>"
+									name="<%= inputTimeName %>"
 								/>
 							</span>
 						</c:when>
@@ -233,7 +238,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 										value = defaultValue;
 									}
 
-									double[] values = ParamUtil.getDoubleValues(request, "ExpandoAttribute--" + escapedName + "--", (double[])value);
+									double[] values = ParamUtil.getDoubleValues(request, "ExpandoAttribute--" + HtmlUtil.escape(name) + "--", (double[])value);
 									%>
 
 									<textarea class="lfr-textarea" id="<%= randomNamespace %><%= escapedName %>" name="<portlet:namespace />ExpandoAttribute--<%= escapedName %>--"><%= StringUtil.merge(values, StringPool.NEW_LINE) %></textarea>
@@ -296,7 +301,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 										value = defaultValue;
 									}
 
-									float[] values = ParamUtil.getFloatValues(request, "ExpandoAttribute--" + escapedName + "--", (float[])value);
+									float[] values = ParamUtil.getFloatValues(request, "ExpandoAttribute--" + HtmlUtil.escape(name) + "--", (float[])value);
 									%>
 
 									<textarea class="lfr-textarea" id="<%= randomNamespace %><%= escapedName %>" name="<portlet:namespace />ExpandoAttribute--<%= escapedName %>--"><%= StringUtil.merge((float[])value, StringPool.NEW_LINE) %></textarea>
@@ -359,7 +364,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 										value = defaultValue;
 									}
 
-									int[] values = ParamUtil.getIntegerValues(request, "ExpandoAttribute--" + escapedName + "--", (int[])value);
+									int[] values = ParamUtil.getIntegerValues(request, "ExpandoAttribute--" + HtmlUtil.escape(name) + "--", (int[])value);
 									%>
 
 									<textarea class="lfr-textarea" id="<%= randomNamespace %><%= escapedName %>" name="<portlet:namespace />ExpandoAttribute--<%= escapedName %>--"><%= StringUtil.merge(values, StringPool.NEW_LINE) %></textarea>
@@ -422,7 +427,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 										value = defaultValue;
 									}
 
-									long[] values = ParamUtil.getLongValues(request, "ExpandoAttribute--" + escapedName + "--", (long[])value);
+									long[] values = ParamUtil.getLongValues(request, "ExpandoAttribute--" + HtmlUtil.escape(name) + "--", (long[])value);
 									%>
 
 									<textarea class="lfr-textarea" id="<%= randomNamespace %><%= escapedName %>" name="<portlet:namespace />ExpandoAttribute--<%= escapedName %>--"><%= StringUtil.merge(values, StringPool.NEW_LINE) %></textarea>
@@ -485,7 +490,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 										value = defaultValue;
 									}
 
-									Number[] values = ParamUtil.getNumberValues(request, "ExpandoAttribute--" + escapedName + "--", (Number[])value);
+									Number[] values = ParamUtil.getNumberValues(request, "ExpandoAttribute--" + HtmlUtil.escape(name) + "--", (Number[])value);
 									%>
 
 									<textarea class="lfr-textarea" id="<%= randomNamespace %><%= escapedName %>" name="<portlet:namespace />ExpandoAttribute--<%= escapedName %>--"><%= StringUtil.merge(values, StringPool.NEW_LINE) %></textarea>
@@ -549,7 +554,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 										value = defaultValue;
 									}
 
-									short[] values = ParamUtil.getShortValues(request, "ExpandoAttribute--" + escapedName + "--", (short[])value);
+									short[] values = ParamUtil.getShortValues(request, "ExpandoAttribute--" + HtmlUtil.escape(name) + "--", (short[])value);
 									%>
 
 									<textarea class="lfr-textarea" id="<%= randomNamespace %><%= escapedName %>" name="<portlet:namespace />ExpandoAttribute--<%= escapedName %>--"><%= StringUtil.merge(values, StringPool.NEW_LINE) %></textarea>
@@ -639,7 +644,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 							}
 							%>
 
-							<liferay-ui:input-localized cssClass="lfr-input-text" id="<%= randomNamespace + escapedName %>" name='<%= "ExpandoAttribute--" + escapedName + "--" %>' xml="<%= xml %>" />
+							<liferay-ui:input-localized cssClass="lfr-input-text" id="<%= randomNamespace + name %>" name='<%= "ExpandoAttribute--" + name + "--" %>' xml="<%= xml %>" />
 						</c:when>
 						<c:otherwise>
 

--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -26,14 +26,15 @@ if (GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-date:di
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-date:cssClass"));
 boolean disabled = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-date:disabled"));
 String dayParam = namespace + request.getAttribute("liferay-ui:input-date:dayParam");
-String dayParamId = namespace + request.getAttribute("liferay-ui:input-date:dayParamId");
+String dayParamId = HtmlUtil.toWordCharacters(dayParam);
 int dayValue = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-date:dayValue"));
 String monthParam = namespace + request.getAttribute("liferay-ui:input-date:monthParam");
-String monthParamId = namespace + request.getAttribute("liferay-ui:input-date:monthParamId");
+String monthParamId = HtmlUtil.toWordCharacters(monthParam);
 int monthValue = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-date:monthValue"));
-String name = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-date:name"));
+String name = namespace + GetterUtil.getString((String)request.getAttribute("liferay-ui:input-date:name"));
+String nameId = HtmlUtil.toWordCharacters(name);
 String yearParam = namespace + request.getAttribute("liferay-ui:input-date:yearParam");
-String yearParamId = namespace + request.getAttribute("liferay-ui:input-date:yearParamId");
+String yearParamId = HtmlUtil.toWordCharacters(yearParam);
 int yearValue = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-date:yearValue"));
 
 Calendar calendar = CalendarFactoryUtil.getCalendar(yearValue, monthValue, dayValue);
@@ -67,21 +68,21 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 <span class="lfr-input-date <%= cssClass %>" id="<%= randomNamespace %>displayDate">
 	<c:choose>
 		<c:when test="<%= BrowserSnifferUtil.isMobile(request) %>">
-			<input class="input-medium" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace + name %>" name="<%= namespace + name %>" type="date" value="<%= format.format(calendar.getTime()) %>" />
+			<input class="input-medium" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= HtmlUtil.escapeAttribute(name) %>" type="date" value="<%= format.format(calendar.getTime()) %>" />
 		</c:when>
 		<c:otherwise>
-			<input class="input-medium" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace + name %>" name="<%= namespace + name %>" placeholder="<%= StringUtil.toLowerCase(simpleDateFormatPattern) %>" type="text" value="<%= format.format(calendar.getTime()) %>" />
+			<input class="input-medium" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= HtmlUtil.escapeAttribute(name) %>" placeholder="<%= StringUtil.toLowerCase(simpleDateFormatPattern) %>" type="text" value="<%= format.format(calendar.getTime()) %>" />
 		</c:otherwise>
 	</c:choose>
 
-	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= dayParamId %>" name="<%= dayParam %>" type="hidden" value="<%= dayValue %>" />
-	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= monthParamId %>" name="<%= monthParam %>" type="hidden" value="<%= monthValue %>" />
-	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= yearParamId %>" name="<%= yearParam %>" type="hidden" value="<%= yearValue %>" />
+	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= dayParamId %>" name="<%= HtmlUtil.escapeAttribute(dayParam) %>" type="hidden" value="<%= dayValue %>" />
+	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= monthParamId %>" name="<%= HtmlUtil.escapeAttribute(monthParam) %>" type="hidden" value="<%= monthValue %>" />
+	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= yearParamId %>" name="<%= HtmlUtil.escapeAttribute(yearParam) %>" type="hidden" value="<%= yearValue %>" />
 </span>
 
 <aui:script use='<%= "aui-datepicker" + (BrowserSnifferUtil.isMobile(request) ? "-native" : StringPool.BLANK) %>'>
 	Liferay.component(
-		'<%= namespace + name %>DatePicker',
+		'<%= nameId %>DatePicker',
 		function() {
 			var datePicker = new A.DatePicker<%= BrowserSnifferUtil.isMobile(request) ? "Native" : StringPool.BLANK %>(
 				{
@@ -97,7 +98,7 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 
 							container.one('#<%= dayParamId %>').attr('disabled', newVal);
 							container.one('#<%= monthParamId %>').attr('disabled', newVal);
-							container.one('#<%= namespace + name %>').attr('disabled', newVal);
+							container.one('#<%= nameId %>').attr('disabled', newVal);
 							container.one('#<%= yearParamId %>').attr('disabled', newVal);
 						},
 						selectionChange: function(event) {
@@ -117,7 +118,7 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 					popover: {
 						zIndex: Liferay.zIndex.TOOLTIP
 					},
-					trigger: '#<%= namespace + name %>'
+					trigger: '#<%= nameId %>'
 				}
 			);
 
@@ -133,9 +134,8 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 		}
 	);
 
-	Liferay.component('<%= namespace + name %>DatePicker');
+	Liferay.component('<%= nameId %>DatePicker');
 </aui:script>
-
 <%!
 private static final String _SIMPLE_DATE_FORMAT_PATTERN_DMY = "dd/MM/yyyy";
 

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -25,7 +25,7 @@ Locale[] availableLocales = (Locale[])request.getAttribute("liferay-ui:input-loc
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-localized:cssClass"));
 String defaultLanguageId = (String)request.getAttribute("liferay-ui:input-localized:defaultLanguageId");
 boolean disabled = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-localized:disabled"));
-String id = (String)request.getAttribute("liferay-ui:input-localized:id");
+String id = HtmlUtil.toWordCharacters((String)request.getAttribute("liferay-ui:input-localized:id"));
 Map<String, Object> dynamicAttributes = (Map<String, Object>)request.getAttribute("liferay-ui:input-localized:dynamicAttributes");
 boolean ignoreRequestValue = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-localized:ignoreRequestValue"));
 String languageId = (String)request.getAttribute("liferay-ui:input-localized:languageId");
@@ -136,14 +136,14 @@ if ((exception != null) && fieldName.equals(focusField)) {
 			</aui:script>
 		</c:when>
 		<c:when test='<%= type.equals("input") %>'>
-			<input class="language-value <%= cssClass %>" dir="<%= mainLanguageDir %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<portlet:namespace /><%= HtmlUtil.escapeAttribute(id + fieldSuffix) %>" name="<portlet:namespace /><%= HtmlUtil.escapeAttribute(name + fieldSuffix) %>" type="text" value="<%= HtmlUtil.escapeAttribute(mainLanguageValue) %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+			<input class="language-value <%= cssClass %>" dir="<%= mainLanguageDir %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<portlet:namespace /><%= id + HtmlUtil.toWordCharacters(fieldSuffix) %>" name="<portlet:namespace /><%= HtmlUtil.escapeAttribute(name + fieldSuffix) %>" type="text" value="<%= HtmlUtil.escapeAttribute(mainLanguageValue) %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
 		</c:when>
 		<c:when test='<%= type.equals("textarea") %>'>
-			<textarea class="language-value <%= cssClass %>" dir="<%= mainLanguageDir %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<portlet:namespace /><%= HtmlUtil.escapeAttribute(id + fieldSuffix) %>" name="<portlet:namespace /><%= HtmlUtil.escapeAttribute(name + fieldSuffix) %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>><%= HtmlUtil.escape(mainLanguageValue) %></textarea>
+			<textarea class="language-value <%= cssClass %>" dir="<%= mainLanguageDir %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<portlet:namespace /><%= id + HtmlUtil.toWordCharacters(fieldSuffix) %>" name="<portlet:namespace /><%= HtmlUtil.escapeAttribute(name + fieldSuffix) %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>><%= HtmlUtil.escape(mainLanguageValue) %></textarea>
 
 			<c:if test="<%= autoSize %>">
 				<aui:script use="aui-autosize-deprecated">
-					A.one('#<portlet:namespace /><%= HtmlUtil.escapeJS(id + fieldSuffix) %>').plug(A.Plugin.Autosize);
+					A.one('#<portlet:namespace /><%= id + HtmlUtil.toWordCharacters(fieldSuffix) %>').plug(A.Plugin.Autosize);
 				</aui:script>
 			</c:if>
 		</c:when>
@@ -250,7 +250,7 @@ if ((exception != null) && fieldName.equals(focusField)) {
 	<aui:script use="aui-char-counter">
 		new A.CharCounter(
 			{
-				input: '#<portlet:namespace /><%= HtmlUtil.escapeJS(id + fieldSuffix) %>',
+				input: '#<portlet:namespace /><%= id + HtmlUtil.toWordCharacters(fieldSuffix) %>',
 				maxLength: <%= maxLength %>
 			}
 		);
@@ -295,7 +295,7 @@ if ((exception != null) && fieldName.equals(focusField)) {
 			var errorLanguageIds = A.Array.dedupe(A.Object.keys(errors));
 
 			Liferay.InputLocalized.register(
-				'<portlet:namespace /><%= HtmlUtil.escapeJS(id + fieldSuffix) %>',
+				'<portlet:namespace /><%= id + HtmlUtil.toWordCharacters(fieldSuffix) %>',
 				{
 					boundingBox: '#<portlet:namespace /><%= id %>BoundingBox',
 					columns: 20,
@@ -305,7 +305,7 @@ if ((exception != null) && fieldName.equals(focusField)) {
 						editor: window['<portlet:namespace /><%= fieldName %>'],
 					</c:if>
 
-					inputPlaceholder: '#<portlet:namespace /><%= HtmlUtil.escapeJS(id + fieldSuffix) %>',
+					inputPlaceholder: '#<portlet:namespace /><%= id + HtmlUtil.toWordCharacters(fieldSuffix) %>',
 					items: availableLanguageIds,
 					itemsError: errorLanguageIds,
 					lazy: <%= !type.equals("editor") %>,
@@ -317,7 +317,7 @@ if ((exception != null) && fieldName.equals(focusField)) {
 			);
 
 			<c:if test="<%= autoFocus %>">
-				Liferay.Util.focusFormField('#<portlet:namespace /><%= HtmlUtil.escapeAttribute(id + fieldSuffix) %>');
+				Liferay.Util.focusFormField('#<portlet:namespace /><%= id + HtmlUtil.toWordCharacters(fieldSuffix) %>');
 			</c:if>
 		</aui:script>
 	</c:when>

--- a/portal-web/docroot/html/taglib/ui/input_time/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_time/page.jsp
@@ -20,17 +20,22 @@
 String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_input_time_page") + StringPool.UNDERLINE;
 
 String amPmParam = namespace + request.getAttribute("liferay-ui:input-time:amPmParam");
+String amPmParamId = HtmlUtil.toWordCharacters(amPmParam);
 int amPmValue = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-time:amPmValue"));
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-time:cssClass"));
-String dateParam = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-time:dateParam"));
+String dateParam = namespace + GetterUtil.getString((String)request.getAttribute("liferay-ui:input-time:dateParam"));
+String dateParamId = HtmlUtil.toWordCharacters(dateParam);
 Date dateValue = (Date)GetterUtil.getObject(request.getAttribute("liferay-ui:input-time:dateValue"));
 boolean disabled = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-time:disabled"));
 String hourParam = namespace + request.getAttribute("liferay-ui:input-time:hourParam");
+String hourParamId = HtmlUtil.toWordCharacters(hourParam);
 int hourValue = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-time:hourValue"));
 String minuteParam = namespace + request.getAttribute("liferay-ui:input-time:minuteParam");
+String minuteParamId = HtmlUtil.toWordCharacters(minuteParam);
 int minuteValue = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-time:minuteValue"));
 int minuteInterval = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-time:minuteInterval"));
-String name = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-time:name"));
+String name = namespace + GetterUtil.getString((String)request.getAttribute("liferay-ui:input-time:name"));
+String nameId = HtmlUtil.toWordCharacters(name);
 
 if (minuteInterval < 1) {
 	minuteInterval = 30;
@@ -65,22 +70,22 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 <span class="lfr-input-time <%= cssClass %>" id="<%= randomNamespace %>displayTime">
 	<c:choose>
 		<c:when test="<%= BrowserSnifferUtil.isMobile(request) %>">
-			<input class="input-small" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace + name %>" name="<%= namespace + name %>" type="time" value="<%= format.format(calendar.getTime()) %>" />
+			<input class="input-small" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= HtmlUtil.escapeAttribute(name) %>" type="time" value="<%= format.format(calendar.getTime()) %>" />
 		</c:when>
 		<c:otherwise>
-			<input class="input-small" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace + name %>" name="<%= namespace + name %>" type="text" placeholder="<%= placeholder %>" value="<%= format.format(calendar.getTime()) %>" />
+			<input class="input-small" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= nameId %>" name="<%= HtmlUtil.escapeAttribute(name) %>" type="text" placeholder="<%= placeholder %>" value="<%= format.format(calendar.getTime()) %>" />
 		</c:otherwise>
 	</c:choose>
 
-	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= hourParam %>" name="<%= hourParam %>" type="hidden" value="<%= hourValue %>" />
-	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= minuteParam %>" name="<%= minuteParam %>" type="hidden" value="<%= minuteValue %>" />
-	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= amPmParam %>" name="<%= amPmParam %>" type="hidden" value="<%= amPmValue %>" />
-	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= dateParam %>" name="<%= dateParam %>" type="hidden" value="<%= dateValue %>" />
+	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= hourParamId %>" name="<%= HtmlUtil.escapeAttribute(hourParam) %>" type="hidden" value="<%= hourValue %>" />
+	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= minuteParamId %>" name="<%= HtmlUtil.escapeAttribute(minuteParam) %>" type="hidden" value="<%= minuteValue %>" />
+	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= amPmParamId %>" name="<%= HtmlUtil.escapeAttribute(amPmParam) %>" type="hidden" value="<%= amPmValue %>" />
+	<input <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= dateParamId %>" name="<%= HtmlUtil.escapeAttribute(dateParam) %>" type="hidden" value="<%= dateValue %>" />
 </span>
 
 <aui:script use='<%= "aui-timepicker" + (BrowserSnifferUtil.isMobile(request) ? "-native" : StringPool.BLANK) %>'>
 	Liferay.component(
-		'<%= namespace + name %>TimePicker',
+		'<%= nameId %>TimePicker',
 		function() {
 			var timePicker = new A.TimePicker<%= BrowserSnifferUtil.isMobile(request) ? "Native" : StringPool.BLANK %>(
 				{
@@ -106,17 +111,17 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 							</c:if>
 
 							if (date) {
-								container.one('#<%= hourParam %>').val(hours);
-								container.one('#<%= minuteParam %>').val(date.getMinutes());
-								container.one('#<%= amPmParam %>').val(amPm);
-								container.one('#<%= dateParam %>').val(date);
+								container.one('#<%= hourParamId %>').val(hours);
+								container.one('#<%= minuteParamId %>').val(date.getMinutes());
+								container.one('#<%= amPmParamId %>').val(amPm);
+								container.one('#<%= dateParamId %>').val(date);
 							}
 						}
 					},
 					popover: {
 						zIndex: Liferay.zIndex.TOOLTIP
 					},
-					trigger: '#<%= namespace + name %>',
+					trigger: '#<%= nameId %>',
 					values: <%= _getHoursJSONArray(minuteInterval, locale) %>
 				}
 			);
@@ -126,14 +131,14 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 
 				var container = instance.get('container');
 
-				return A.Date.parse(container.one('#<%= dateParam %>').val());
+				return A.Date.parse(container.one('#<%= dateParamId %>').val());
 			};
 
 			return timePicker;
 		}
 	);
 
-	Liferay.component('<%= namespace + name %>TimePicker');
+	Liferay.component('<%= nameId %>TimePicker');
 </aui:script>
 
 <%!

--- a/util-taglib/src/com/liferay/taglib/ui/InputDateTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputDateTag.java
@@ -14,7 +14,6 @@
 
 package com.liferay.taglib.ui;
 
-import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.taglib.util.IncludeTag;
 
@@ -112,9 +111,6 @@ public class InputDateTag extends IncludeTag {
 		request.setAttribute("liferay-ui:input-date:cssClass",_cssClass);
 		request.setAttribute("liferay-ui:input-date:dayParam", _dayParam);
 		request.setAttribute(
-			"liferay-ui:input-date:dayParamId",
-			FriendlyURLNormalizerUtil.normalize(_dayParam));
-		request.setAttribute(
 			"liferay-ui:input-date:dayValue", String.valueOf(_dayValue));
 		request.setAttribute(
 			"liferay-ui:input-date:disabled", String.valueOf(_disabled));
@@ -129,15 +125,9 @@ public class InputDateTag extends IncludeTag {
 			"liferay-ui:input-date:monthAndYearParam", _monthAndYearParam);
 		request.setAttribute("liferay-ui:input-date:monthParam", _monthParam);
 		request.setAttribute(
-			"liferay-ui:input-date:monthParamId",
-			FriendlyURLNormalizerUtil.normalize(_monthParam));
-		request.setAttribute(
 			"liferay-ui:input-date:monthValue", String.valueOf(_monthValue));
 		request.setAttribute("liferay-ui:input-date:name", _name);
 		request.setAttribute("liferay-ui:input-date:yearParam", _yearParam);
-		request.setAttribute(
-			"liferay-ui:input-date:yearParamId",
-			FriendlyURLNormalizerUtil.normalize(_yearParam));
 		request.setAttribute(
 			"liferay-ui:input-date:yearValue", String.valueOf(_yearValue));
 	}


### PR DESCRIPTION
This is the code's logic.

When a String is used in javascript and id, I convert it to a 'word' String;
When the String is used in html id or other attribute I convert it;
When the String is used in liferay taglib attribute, I don't escape/convert it at where it calls, but escape/convert it in the taglib itself in order to prevent over escape/convert problem;
HtmlUtil is called in the jsp, but not in the XXTag.java

So I fixed the related taglib and fixed some misused escape.
