### PR TITLE
LPS-55285 LPS-55371 - We don't need any escape. This was wrongly introduced by LPS-46959 because it was originally introduce in a img alt attribute but it's not used like that here.

### DIFF
--- a/portal-web/docroot/html/portlet/message_boards/thread_columns.jspf
+++ b/portal-web/docroot/html/portlet/message_boards/thread_columns.jspf
@@ -22,10 +22,10 @@
 >
 	<c:choose>
 		<c:when test="<%= MBThreadLocalServiceUtil.hasAnswerMessage(thread.getThreadId()) %>">
-			<liferay-ui:message escape="<%= true %>" key="resolved" />
+			<liferay-ui:message key="resolved" />
 		</c:when>
 		<c:when test="<%= thread.isQuestion() %>">
-			<liferay-ui:message escape="<%= true %>" key="waiting-for-an-answer" />
+			<liferay-ui:message key="waiting-for-an-answer" />
 		</c:when>
 	</c:choose>
 </liferay-ui:search-container-column-text>

--- a/portal-web/docroot/html/portlet/message_boards/thread_columns.jspf
+++ b/portal-web/docroot/html/portlet/message_boards/thread_columns.jspf
@@ -22,10 +22,10 @@
 >
 	<c:choose>
 		<c:when test="<%= MBThreadLocalServiceUtil.hasAnswerMessage(thread.getThreadId()) %>">
-			<liferay-ui:message escapeAttribute="<%= true %>" key="resolved" />
+			<liferay-ui:message escape="<%= true %>" key="resolved" />
 		</c:when>
 		<c:when test="<%= thread.isQuestion() %>">
-			<liferay-ui:message escapeAttribute="<%= true %>" key="waiting-for-an-answer" />
+			<liferay-ui:message escape="<%= true %>" key="waiting-for-an-answer" />
 		</c:when>
 	</c:choose>
 </liferay-ui:search-container-column-text>

--- a/portal-web/docroot/html/portlet/message_boards_admin/view.jsp
+++ b/portal-web/docroot/html/portlet/message_boards_admin/view.jsp
@@ -256,10 +256,10 @@ if ((category != null) && layout.isTypeControlPanel()) {
 							>
 								<c:choose>
 									<c:when test="<%= MBThreadLocalServiceUtil.hasAnswerMessage(thread.getThreadId()) %>">
-										<liferay-ui:message escapeAttribute="<%= true %>" key="resolved" />
+										<liferay-ui:message escape="<%= true %>" key="resolved" />
 									</c:when>
 									<c:when test="<%= thread.isQuestion() %>">
-										<liferay-ui:message escapeAttribute="<%= true %>" key="waiting-for-an-answer" />
+										<liferay-ui:message escape="<%= true %>" key="waiting-for-an-answer" />
 									</c:when>
 								</c:choose>
 							</liferay-ui:search-container-column-text>

--- a/portal-web/docroot/html/portlet/message_boards_admin/view.jsp
+++ b/portal-web/docroot/html/portlet/message_boards_admin/view.jsp
@@ -256,10 +256,10 @@ if ((category != null) && layout.isTypeControlPanel()) {
 							>
 								<c:choose>
 									<c:when test="<%= MBThreadLocalServiceUtil.hasAnswerMessage(thread.getThreadId()) %>">
-										<liferay-ui:message escape="<%= true %>" key="resolved" />
+										<liferay-ui:message key="resolved" />
 									</c:when>
 									<c:when test="<%= thread.isQuestion() %>">
-										<liferay-ui:message escape="<%= true %>" key="waiting-for-an-answer" />
+										<liferay-ui:message key="waiting-for-an-answer" />
 									</c:when>
 								</c:choose>
 							</liferay-ui:search-container-column-text>

--- a/portal-web/docroot/html/portlet/message_boards_admin/view.jsp
+++ b/portal-web/docroot/html/portlet/message_boards_admin/view.jsp
@@ -253,8 +253,16 @@ if ((category != null) && layout.isTypeControlPanel()) {
 							<liferay-ui:search-container-column-text
 								href="<%= rowURL %>"
 								name="flag"
-								value='<%= MBThreadLocalServiceUtil.hasAnswerMessage(thread.getThreadId()) ? LanguageUtil.get(request, "resolved") : LanguageUtil.get(request, "waiting-for-an-answer") %>'
-							/>
+							>
+								<c:choose>
+									<c:when test="<%= MBThreadLocalServiceUtil.hasAnswerMessage(thread.getThreadId()) %>">
+										<liferay-ui:message escapeAttribute="<%= true %>" key="resolved" />
+									</c:when>
+									<c:when test="<%= thread.isQuestion() %>">
+										<liferay-ui:message escapeAttribute="<%= true %>" key="waiting-for-an-answer" />
+									</c:when>
+								</c:choose>
+							</liferay-ui:search-container-column-text>
 
 							<liferay-ui:search-container-column-text
 								href="<%= rowURL %>"


### PR DESCRIPTION
Hey @samuelkong 

I removed the escape because I thikn that we don't need it at all, but I wanted you to double check it in case I'm missing something.

