### PR TITLE
LPS-66855 HtmlUtil.escape does not escape control characters

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -248,8 +248,15 @@ public class HtmlImpl implements Html {
 		for (int i = 0; i < text.length(); i++) {
 			char c = text.charAt(i);
 
-			if ((c > 255) || (c == CharPool.DASH) ||
-				(c == CharPool.UNDERLINE) || Character.isLetterOrDigit(c)) {
+			if ((mode == ESCAPE_MODE_ATTRIBUTE) &&
+				(!_isValidXmlCharacter(c) ||
+				 _isUnicodeCompatibilityCharacter(c))) {
+
+				sb.append(StringPool.SPACE);
+			}
+			else if ((c > 255) || (c == CharPool.DASH) ||
+					 (c == CharPool.UNDERLINE) ||
+					 Character.isLetterOrDigit(c)) {
 
 				sb.append(c);
 			}
@@ -277,7 +284,7 @@ public class HtmlImpl implements Html {
 			}
 		}
 
-		if (sb.length() == text.length()) {
+		if ((mode != ESCAPE_MODE_ATTRIBUTE) && (sb.length() == text.length())) {
 			return text;
 		}
 

--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -839,7 +839,8 @@ public class HtmlImpl implements Html {
 	private boolean _isValidXmlCharacter(char c) {
 		if ((c == '\u0009') || (c == CharPool.NEW_LINE) ||
 			(c == CharPool.RETURN) || ((c >= '\u0020') && (c <= '\ud7ff')) ||
-			((c >= '\ue000') && (c <= '\ufffd'))) {
+			((c >= '\ue000') && (c <= '\ufffd')) ||
+			Character.isLowSurrogate(c) || Character.isHighSurrogate(c)) {
 
 			return true;
 		}

--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -165,6 +165,12 @@ public class HtmlImpl implements Html {
 					break;
 			}
 
+			if (!_isValidXmlCharacter(c) ||
+				_isUnicodeCompatibilityCharacter(c)) {
+
+				replacement = StringPool.SPACE;
+			}
+
 			if (replacement != null) {
 				if (sb == null) {
 					sb = new StringBundler();
@@ -830,6 +836,28 @@ public class HtmlImpl implements Html {
 		}
 
 		return pos;
+	}
+
+	private boolean _isUnicodeCompatibilityCharacter(char c) {
+		if (((c >= '\u007f') && (c <= '\u0084')) ||
+			((c >= '\u0086') && (c <= '\u009f')) ||
+			((c >= '\ufdd0') && (c <= '\ufdef'))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isValidXmlCharacter(char c) {
+		if ((c == '\u0009') || (c == CharPool.NEW_LINE) ||
+			(c == CharPool.RETURN) || ((c >= '\u0020') && (c <= '\ud7ff')) ||
+			((c >= '\ue000') && (c <= '\ufffd'))) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final String[] _MS_WORD_HTML = new String[] {

--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -109,15 +109,86 @@ public class HtmlImpl implements Html {
 		// http://www.owasp.org/index.php/Cross_Site_Scripting
 		// #How_to_Protect_Yourself
 
-		return StringUtil.replace(
-			text,
-			new char[] {
-				'<', '>', '&', '"', '\'', '\u00bb', '\u2013', '\u2014', '\u2028'
-			},
-			new String[] {
-				"&lt;", "&gt;", "&amp;", "&#34;", "&#39;", "&#187;", "&#x2013;",
-				"&#x2014;", "&#x2028;"
-			});
+		StringBundler sb = null;
+
+		int lastReplacementIndex = 0;
+
+		for (int i = 0; i < text.length(); i++) {
+			char c = text.charAt(i);
+
+			String replacement = null;
+
+			switch (c) {
+				case '<':
+					replacement = "&lt;";
+
+					break;
+
+				case '>':
+					replacement = "&gt;";
+
+					break;
+
+				case '&':
+					replacement = "&amp;";
+
+					break;
+
+				case '"':
+					replacement = "&#34;";
+
+					break;
+
+				case '\'':
+					replacement = "&#39;";
+
+					break;
+
+				case '\u00bb':
+					replacement = "&#187;";
+
+					break;
+
+				case '\u2013':
+					replacement = "&#x2013;";
+
+					break;
+
+				case '\u2014':
+					replacement = "&#x2014;";
+
+					break;
+
+				case '\u2028':
+					replacement = "&#x8232;";
+
+					break;
+			}
+
+			if (replacement != null) {
+				if (sb == null) {
+					sb = new StringBundler();
+				}
+
+				if (i > lastReplacementIndex) {
+					sb.append(text.substring(lastReplacementIndex, i));
+				}
+
+				sb.append(replacement);
+
+				lastReplacementIndex = i + 1;
+			}
+		}
+
+		if (sb == null) {
+			return text;
+		}
+
+		if (lastReplacementIndex < text.length()) {
+			sb.append(text.substring(lastReplacementIndex));
+		}
+
+		return sb.toString();
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -143,7 +143,7 @@ public class HtmlImpl implements Html {
 				replacement = "&#x2014;";
 			}
 			else if (c == '\u2028') {
-				replacement = "&#x8232;";
+				replacement = "&#x2028;";
 			}
 			else if (!_isValidXmlCharacter(c) ||
 					 _isUnicodeCompatibilityCharacter(c)) {

--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -118,55 +118,35 @@ public class HtmlImpl implements Html {
 
 			String replacement = null;
 
-			switch (c) {
-				case '<':
-					replacement = "&lt;";
-
-					break;
-
-				case '>':
-					replacement = "&gt;";
-
-					break;
-
-				case '&':
-					replacement = "&amp;";
-
-					break;
-
-				case '"':
-					replacement = "&#34;";
-
-					break;
-
-				case '\'':
-					replacement = "&#39;";
-
-					break;
-
-				case '\u00bb':
-					replacement = "&#187;";
-
-					break;
-
-				case '\u2013':
-					replacement = "&#x2013;";
-
-					break;
-
-				case '\u2014':
-					replacement = "&#x2014;";
-
-					break;
-
-				case '\u2028':
-					replacement = "&#x8232;";
-
-					break;
+			if (c == '<') {
+				replacement = "&lt;";
 			}
-
-			if (!_isValidXmlCharacter(c) ||
-				_isUnicodeCompatibilityCharacter(c)) {
+			else if (c == '>') {
+				replacement = "&gt;";
+			}
+			else if (c == '&') {
+				replacement = "&amp;";
+			}
+			else if (c == '"') {
+				replacement = "&#34;";
+			}
+			else if (c == '\'') {
+				replacement = "&#39;";
+			}
+			else if (c == '\u00bb') {
+				replacement = "&#187;";
+			}
+			else if (c == '\u2013') {
+				replacement = "&#x2013;";
+			}
+			else if (c == '\u2014') {
+				replacement = "&#x2014;";
+			}
+			else if (c == '\u2028') {
+				replacement = "&#x8232;";
+			}
+			else if (!_isValidXmlCharacter(c) ||
+					 _isUnicodeCompatibilityCharacter(c)) {
 
 				replacement = StringPool.SPACE;
 			}

--- a/portal-impl/test/unit/com/liferay/portal/util/HtmlImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/HtmlImplTest.java
@@ -154,6 +154,11 @@ public class HtmlImplTest {
 	}
 
 	@Test
+	public void testEscapeUTF8SupplementaryCharacter() {
+		assertUnchangedEscape("\uD83D\uDC31");
+	}
+
+	@Test
 	public void testEscapeWhitespace() {
 		assertUnchangedEscape(" ");
 	}


### PR DESCRIPTION
Hi Sam,

I fixed two bugs:
* I'm not sure if the change of U+2028 was intentional or not, but the result was not valid.
* I allowed or 4 bytes UTF-8 characters in the output, though some of them may be invalid. But without Unicode code points in HtmlImpl we have no option to test them.

I noticed the allowed characters is for XML documents, not HTML (https://www.w3.org/TR/REC-xml/#charsets). Why Veracode wants us to fix this when we use HTML output? The only thing for HTML I found is here: https://www.w3.org/TR/html5/syntax.html#preprocessing-the-input-stream

I leave the URL/CSS/JS/attribute check for you, I'm not sure what is correct and what not.

Thanks!

https://issues.liferay.com/browse/LPS-66855