### PR TITLE
LPS-70650 Autofocus not being set on Sign In portlet

### DIFF
--- a/portal-web/docroot/html/taglib/aui/form/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/form/end.jsp
@@ -27,6 +27,7 @@
 
 <%
 String fullName = namespace + HtmlUtil.escapeJS(name);
+String autoFocusTagId = GetterUtil.getString(request.getAttribute("autoFocusTagId"));
 %>
 
 <aui:script use="liferay-form">
@@ -84,6 +85,9 @@ String fullName = namespace + HtmlUtil.escapeJS(name);
 
 	<c:if test="<%= Validator.isNotNull(onSubmit) %>">
 		A.all('#<%= fullName %> .input-container').removeAttribute('disabled');
+		<c:if test="<%= Validator.isNotNull(autoFocusTagId) %>">
+			Liferay.Util.focusFormField('#<%= autoFocusTagId %>');
+		</c:if>
 	</c:if>
 
 	Liferay.fire(

--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -372,9 +372,7 @@ boolean choiceField = checkboxField || radioField;
 		</c:choose>
 
 		<c:if test="<%= autoFocus %>">
-			<aui:script>
-				Liferay.Util.focusFormField('#<%= namespace + id %>');
-			</aui:script>
+			<%request.setAttribute("autoFocusTagId",namespace + id); %>
 		</c:if>
 	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
Modify this issue by re-focus after form rending ready.
The logic for original code is correct and could well running in chrome and Firefox but cannot be well parsing in IE engine.
For details,please refer to the related ticket  below.

LPS-65437 
LPS-72323


