### PR TITLE
LPS-74562 Tooltip message for ratings (type like) is not updated

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
@@ -503,7 +503,9 @@ AUI.add(
 						var ratingThumbDown = elements.item(1);
 						var ratingThumbUp = elements.item(0);
 
-						var ratingThumbDownCssClassOn = ratingThumbDown.hasClass(cssClassesOn);
+						if (ratingThumbDown) {
+							var ratingThumbDownCssClassOn = ratingThumbDown.hasClass(cssClassesOn);
+						}
 						var ratingThumbUpCssClassOn = ratingThumbUp.hasClass(cssClassesOn);
 
 						var thumbDownMessage = '';


### PR DESCRIPTION
There is no `ratingThumbDownCssClassOn` when we use `type="like"`.
JavaScript stops running when error occurs, and tooltip did not change.

fix: `ratingThumbDownCssClassOn` should be wrapped in `if (ratingThumbDown)`.
