### PR TITLE
LPS-72939 url starting with colon makes no sense, if we make trim it …

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -922,7 +922,7 @@ public class PortalImpl implements Portal {
 
 		int pos = domain.indexOf(CharPool.COLON);
 
-		if (pos != -1) {
+		if (pos > 0) {
 			domain = domain.substring(0, pos);
 		}
 


### PR DESCRIPTION
…in this if condition, then the domain becomes empty, which is later considered as portal relative url